### PR TITLE
他のプラグインの影響を受けないようにする

### DIFF
--- a/README.md
+++ b/README.md
@@ -289,6 +289,11 @@ location.reload();
 ```
 dcm-admin-menu-organizer/
 ├── dcm-admin-menu-organizer.php  # メインファイル
+├── assets/
+│   ├── css/
+│   │   └── dcm-admin-menu-organizer.css
+│   └── js/
+│       └── dcm-admin-accordion.js
 └── README.md                      # このファイル
 ```
 
@@ -300,9 +305,10 @@ dcm-admin-menu-organizer/
 
 - `admin_menu` (優先度: 10) - 設定ページを追加
 - `admin_init` - 設定を登録
-- `admin_menu` (優先度: 999) - メニューを並び替え
-- `admin_enqueue_scripts` - セパレーター用のCSSを出力
-- `admin_enqueue_scripts` - アコーディオン用のJavaScript/CSSを出力
+- `admin_head` (優先度: PHP_INT_MAX) - メニューを並び替え（最終確定後に適用）
+- `admin_enqueue_scripts` - 静的CSSを読み込み
+- `admin_footer` - 動的CSSを出力
+- `admin_footer` - アコーディオン用のJSデータを出力
 
 #### フィルターフック
 
@@ -337,6 +343,13 @@ add_filter( 'dcm_admin_menu_organizer_config_file', function( $config_file ) {
 ## ライセンス
 
 GPL v2 or later
+
+## Changelog
+
+### 1.0.1
+- メニュー並び替えの実行タイミングを `admin_head` 終盤に変更
+- 動的CSS/JSデータの出力タイミングを `admin_footer` に移動
+- 静的CSSをファイル化して読み込み
 
 ## サポート
 

--- a/assets/css/dcm-admin-menu-organizer.css
+++ b/assets/css/dcm-admin-menu-organizer.css
@@ -1,0 +1,56 @@
+/* static styles for admin menu organizer */
+#adminmenu li[id^="separator-"] {
+    margin-top: 6px;
+    margin-bottom: 6px;
+}
+
+#adminmenu li.dcm-menu-before-separator ul.wp-submenu {
+    padding-bottom: 0;
+}
+
+#adminmenu li.dcm-menu-before-separator {
+    margin-bottom: 0;
+}
+
+.dcm-accordion-separator {
+    cursor: pointer;
+    position: relative;
+}
+
+.dcm-accordion-separator:hover::after {
+    opacity: 0.8;
+}
+
+.dcm-accordion-separator::before {
+    content: "\f140";
+    /* dashicons-arrow-down */
+    position: absolute;
+    right: 12px;
+    top: 50%;
+    transform: translateY(-50%);
+    font-family: dashicons;
+    font-size: 16px;
+    line-height: 1;
+    color: #fff;
+    transition: transform 0.2s ease;
+    pointer-events: none;
+    z-index: 1;
+}
+
+.dcm-accordion-separator.dcm-collapsed::before {
+    content: "\f139";
+    /* dashicons-arrow-right */
+}
+
+.dcm-accordion-menu-item {
+    transition: all 0.3s ease;
+}
+
+.dcm-accordion-menu-item.dcm-hidden {
+    display: none !important;
+}
+
+body.folded #adminmenu > li.dcm-accordion-separator::after {
+    /* Use a full-width space to hide label text */
+    content: "\3000";
+}

--- a/tests/playwright/tests/accordion-lock.spec.js
+++ b/tests/playwright/tests/accordion-lock.spec.js
@@ -6,12 +6,18 @@ test('現在地グループのセパレーターは初期展開されるが、�
   const user = process.env.WP_ADMIN_USER || 'cursor';
   const pass = process.env.WP_ADMIN_PASS || 'cursor';
 
-  const settingsPath = '/wp-admin/options-general.php?page=dcm-menu-organizer';
-  const dashboardPath = '/wp-admin/index.php';
+  const settingsPath = 'wp-admin/options-general.php?page=dcm-menu-organizer';
+  const dashboardPath = 'wp-admin/index.php';
+  const loginUrl = process.env.WP_LOGIN_URL || '';
 
   // settingsページへ行き、ログイン画面ならログインして戻る
   await page.goto(settingsPath, { waitUntil: 'domcontentloaded' });
-  if (page.url().includes('/wp-login.php')) {
+  if (!(await page.locator('#user_login').count()) && loginUrl) {
+    const redirectUrl = `${loginUrl}?redirect_to=${encodeURIComponent(settingsPath)}`;
+    await page.goto(redirectUrl, { waitUntil: 'domcontentloaded' });
+  }
+
+  if (page.url().includes('/wp-login.php') || await page.locator('#user_login').count()) {
     await page.locator('#user_login').fill(user);
     await page.locator('#user_pass').fill(pass);
     // wait を先に張ってからクリック（取りこぼし防止）


### PR DESCRIPTION
## Summary
- メニュー並び替えを admin_head (PHP_INT_MAX) で適用
- セパレーター/アコーディオンの静的CSSをファイル化し、動的CSSとJSデータは footer で出力
- グループ内に表示メニューが無い場合はセパレーターを出さない
- PlaywrightテストのログインURL対応と入力/正規表現を修正

## Test plan
- [x] WP_BASE_URL=http://local.xxxxxxxxxx.jp WP_LOGIN_URL=http://local.xxxxxxxxxx.jp/xx-xxx/ npx playwright test

Fixes #3

Made with [Cursor](https://cursor.com)